### PR TITLE
Changing the input query to accommodate metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,19 @@ $ npm install pfql
 
 Example of sets of rules:
 ```javascript
-let setsOfRules = [
-   [
-      {
-         Npos: [
+let query = [
+    {
+        rules: [
             {
-               resource: 'pfam28',
-               feature: 'MCPsignal'
+                Npos: [
+                    {
+                    resource: 'pfam28',
+                    feature: 'MCPsignal'
+                    }
+                ]
             }
-         ]
-      }
-   ]
+        ]
+    }
 ]
 ```
 

--- a/manual.md
+++ b/manual.md
@@ -94,16 +94,18 @@ let sampleData = [
     }
   ]
 let query = [
-    [
-       {
-          Npos: [
-             {
-                resource: 'pfam28',
-                feature: 'MCPsignal'
-             }
-          ]
-       }
-    ]
+    {
+        rules:  [
+            {
+                Npos: [
+                    {
+                        resource: 'pfam28',
+                        feature: 'MCPsignal'
+                    }
+                ]
+            }
+        ]
+    }
 ]
 
 let pfqlService = new pfql.PFQLService([query])
@@ -135,32 +137,35 @@ In PFQL, there are two types of rules: **non-positional** and **positional**. Th
 
 The rules are passed as a JSON object to PFQL and it has two keys: `Npos` for non-positional rules and `pos` for positional rules. None of these keys are mandatory and PFQL will return `true` match to any sequence if rules are an empty object. Other keys will be ignored. PQFL will throw an `Error` if the constructor receives no rules.
 
-The way rules are organized in PFQL is the following:
+The organization of PFQL rules obeys the following structure:
 
-* Query - Array containing sets of rules that define protein family. Each element is a protein family
-  * Sets of Rules - Array containing sets of rules.
-    * Set of rules - Array containing objects with positional and non-positional rules that must match
-      * rule - single instruction or set of instructions that must match.
-        * instruction - single snipet of matching definition.
+* query - Array containing collections of sets of rules for a single protein family.
+    * collections of sets of rules - Object containing sets of rules under the key `rules`.
+        * sets of rules - Array containing objects with positional and non-positional rules that must match
+            * set of rules - Object containing rule under the key `pos` and `Npos`.
+                * rule - set of instructions that must match.
+                    * instruction - single snippet of matching definition.
 
-Example of a simple query containing only 1 protein family definition:
+Example of a simple query containing 1 protein family definition:
 
 ```javascript
 let setsOfRules = [ // query
-    [ // set of rules
-        {
-            pos: [ //rule
-                { //instruction
-                    resource: 'fql',
-                    feature: '^'
-                },
-                {
-                    resources: 'pfam28',
-                    feature: 'CheW'
-                },
-            ]
-        }
-    ]
+    { //collection of rules
+        rules: [ //sets of rules
+            { //set of rules
+                pos: [ //rule
+                    { //instruction
+                        resource: 'fql',
+                        feature: '^'
+                    },
+                    {
+                        resources: 'pfam28',
+                        feature: 'CheW'
+                    },
+                ]
+            }
+        ]
+    }
 ]
 ```
 
@@ -168,95 +173,106 @@ Example of a more complex query containing 3 protein family definitions:
 
 ```javascript
 let setsOfRules = [ //query
-    [ // first sets of rules
-        { //set of rules
-            pos: [ // rule
-                { // instruction
-                    resource: 'pfam28',
-                    feature: 'CheW'
-                }
-            ]
-        }
-    ],
-    [ // second sets of rules
-        { // set of rules
-            pos: [ // rule
-                { // instruction
-                    resource: 'fql',
-                    feature: '^'
-                },
-                { // instruction
-                    resource: 'das',
-                    feature: 'TM',
-                    count: '{1}'
-                },
-                { // instruction
-                    resource: 'pfam28',
-                    feature: '.*',
-                    count: '{1,}'
-                },
-                { // instruction
-                    resource: 'das',
-                    feature: 'TM',
-                    count: '{1}'
-                },
-                { // instruction
-                    resource: 'pfam28',
-                    feature: '.*',
-                    count: '{1,}'
-                },
-                { // instruction
-                    resource: 'pfam28',
-                    feature: 'MCPsignal',
-                    count: '{1}'
-                },
-                { // instruction
-                    resource: 'fql',
-                    feature: '$'
-                }
-            ]
-        }
-    ],
-    [ // third sets of rules
-        { // set of rules 1
-            pos: [ // rule
-                { // instruction
-                    resource: 'fql',
-                    feature: '^'
-                },
-                { // instruction
-                    resource: 'pfam28',
-                    feature: '.*',
-                    count: '{2}'
-                },
-                { // instruction
-                    resource: 'fql',
-                    feature: '$'
-                }
-            ]
-        },
-        { // set of rules 2
-            pos: [ // rule
-                { // instruction
-                    resource: 'fql',
-                    feature: '^'
-                },
-                { // instruction
-                    resource: 'das',
-                    feature: 'TM',
-                    count: '{2}'
-                }
-            ],
-            Npos: [ // rule
-                { // instruction
-                    resource: 'pfam28',
-                    feature: 'HAMP'
-                }
-            ]
-        },
-    ]
+    { //collection of rules for protein 1
+        rules: [ //sets of rules
+            { //set of rules
+                pos: [ // rule
+                    { // instruction
+                        resource: 'pfam28',
+                        feature: 'CheW'
+                    }
+                ]
+            }
+        ]
+    },
+    { //collection of rules for protein 2
+        rules:  [ //sets of rules
+            { // set of rules
+                pos: [ // rule
+                    { // instruction
+                        resource: 'fql',
+                        feature: '^'
+                    },
+                    { // instruction
+                        resource: 'das',
+                        feature: 'TM',
+                        count: '{1}'
+                    },
+                    { // instruction
+                        resource: 'pfam28',
+                        feature: '.*',
+                        count: '{1,}'
+                    },
+                    { // instruction
+                        resource: 'das',
+                        feature: 'TM',
+                        count: '{1}'
+                    },
+                    { // instruction
+                        resource: 'pfam28',
+                        feature: '.*',
+                        count: '{1,}'
+                    },
+                    { // instruction
+                        resource: 'pfam28',
+                        feature: 'MCPsignal',
+                        count: '{1}'
+                    },
+                    { // instruction
+                        resource: 'fql',
+                        feature: '$'
+                    }
+                ]
+            }
+        ]
+    },
+    { //collection of rules for protein 3
+        rules: [ // sets of rules
+            { // set of rules 1
+                pos: [ // rule
+                    { // instruction
+                        resource: 'fql',
+                        feature: '^'
+                    },
+                    { // instruction
+                        resource: 'pfam28',
+                        feature: '.*',
+                        count: '{2}'
+                    },
+                    { // instruction
+                        resource: 'fql',
+                        feature: '$'
+                    }
+                ]
+            },
+            { // set of rules 2
+                pos: [ // rule 1
+                    { // instruction
+                        resource: 'fql',
+                        feature: '^'
+                    },
+                    { // instruction
+                        resource: 'das',
+                        feature: 'TM',
+                        count: '{2}'
+                    }
+                ],
+                Npos: [ // rule 2
+                    { // instruction
+                        resource: 'pfam28',
+                        feature: 'HAMP'
+                    }
+                ]
+            },
+        ]
+    }
 ]
 ```
+
+#### What's the reason behind the key `rules`?
+
+We may want to keep the metadata related to that particular collection of sets of rules. To accommodate that request, we included sets of rules in an object under the key `rules`. We now can store related metadata under other keys such as `meta`.
+
 
 Let's explore the types of rules:
 

--- a/manual.md
+++ b/manual.md
@@ -386,7 +386,7 @@ If you want to select all sequences with at least 1 match to CheW domain in pfam
 
 You can also pass alternative rules. For that you need a new object in the *set of rules*. For example:
 
-If you want to select all sequences with at least 1 match to CheW domain in pfam28 OR only 1 match to HATPase_c domain in pfam28:
+If you want to select all sequences with at least 2 match to CheW domain in pfam28 OR only 1 match to HATPase_c domain in pfam28:
 
 ```javascript
 [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pfql",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pfql",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "PFQL - Protein Feature Query Language",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pfql",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "PFQL - Protein Feature Query Language",
   "main": "index.js",
   "scripts": {

--- a/src/PFQLService.js
+++ b/src/PFQLService.js
@@ -27,7 +27,7 @@ class PFQLService {
 			this.resources = [...Array(this.query.length).keys()].map((i) => [])
 			this.query.forEach((setsOfRules, ruleIndex) => {
 				let parsedRules = []
-				setsOfRules.forEach((rules) => {
+				setsOfRules.rules.forEach((rules) => {
 					this._isValidRule(rules)
 					parsedRules.push(this._parseRules(rules, ruleIndex))
 				})

--- a/src/PFQLService.tests.js
+++ b/src/PFQLService.tests.js
@@ -12,7 +12,11 @@ describe('Feature Query Language - FQL', function() {
 			expect(pfqlService.initRules.bind(pfqlService)).to.throw('No rules have been passed in the constructor')
 		})
 		it('If empty rules are passed, it should match any ', function() {
-			let setsOfRules = [{}]
+			let setsOfRules = {
+				rules: [{
+					rules: []
+				}]
+			}
 			let expected = [
 				[0], // CheW | CheW
 				[0], // CheW | Response_reg
@@ -51,7 +55,14 @@ describe('Feature Query Language - FQL', function() {
 	})
 	describe('Nuts and bolts ::', function() {
 		it('check behaviour _addResources with two ruleIndex', function() {
-			let	pfqlService = new PFQLService([[], []])
+			let	pfqlService = new PFQLService([
+				{
+					rules: []
+				},
+				{
+					rules: []
+				}
+			])
 			pfqlService.initRules()
 			let rc = 'pfam28'
 			pfqlService._addResources(rc, 0)
@@ -59,7 +70,7 @@ describe('Feature Query Language - FQL', function() {
 			expect(pfqlService.resources).eql([['pfam28'], ['pfam28']])
 		})
 		it('check behaviour _addResources with single ruleIndex and adding same resource twice', function() {
-			let	pfqlService = new PFQLService([[]])
+			let	pfqlService = new PFQLService([{rules: []}])
 			pfqlService.initRules()
 			let rc = 'pfam28'
 			pfqlService._addResources(rc, 0)
@@ -70,7 +81,7 @@ describe('Feature Query Language - FQL', function() {
 			expect(pfqlService.resources).eql([['pfam28', 'das']])
 		})
 		it('check behaviour _addResources with two ruleIndex and adding same resource twice', function() {
-			let	pfqlService = new PFQLService([[], []])
+			let	pfqlService = new PFQLService([{rules: []}, {rules: []}])
 			pfqlService.initRules()
 			let rc = 'pfam28'
 			pfqlService._addResources(rc, 0)
@@ -85,26 +96,28 @@ describe('Feature Query Language - FQL', function() {
 			expect(pfqlService.resources).eql([['pfam28', 'das'], ['pfam28', 'das']])
 		})
 		it('check behaviour _processFeaturesInfo', function() {
-			let setsOfRules = [
-				{
-					pos: [
-						{
-							resource: 'pfam28',
-							feature: 'CheW'
-						},
-						{
-							resource: 'pfam28',
-							feature: 'Response_reg'
-						}
-					],
-					Npos: [
-						{
-							resource: 'das',
-							feature: 'TM'
-						}
-					]
-				}
-			]
+			let setsOfRules = {
+				rules: [
+					{
+						pos: [
+							{
+								resource: 'pfam28',
+								feature: 'CheW'
+							},
+							{
+								resource: 'pfam28',
+								feature: 'Response_reg'
+							}
+						],
+						Npos: [
+							{
+								resource: 'das',
+								feature: 'TM'
+							}
+						]
+					}
+				]
+			}
 			let	pfqlService = new PFQLService([setsOfRules])
 			pfqlService.initRules()
 			let info = {
@@ -132,30 +145,32 @@ describe('Feature Query Language - FQL', function() {
 			)
 		})
 		it('check behaviour _processFeaturesInfo with different resources', function() {
-			let setsOfRules = [
-				{
-					pos: [
-						{
-							resource: 'pfam28',
-							feature: 'CheW'
-						},
-						{
-							resource: 'pfam28',
-							feature: 'Response_reg'
-						}
-					],
-					Npos: [
-						{
-							resource: 'das',
-							feature: 'TM'
-						},
-						{
-							resource: 'smart',
-							feature: 'SM1049'
-						}
-					]
-				}
-			]
+			let setsOfRules = {
+				rules: [
+					{
+						pos: [
+							{
+								resource: 'pfam28',
+								feature: 'CheW'
+							},
+							{
+								resource: 'pfam28',
+								feature: 'Response_reg'
+							}
+						],
+						Npos: [
+							{
+								resource: 'das',
+								feature: 'TM'
+							},
+							{
+								resource: 'smart',
+								feature: 'SM1049'
+							}
+						]
+					}
+				]
+			}
 			let	pfqlService = new PFQLService([setsOfRules])
 			pfqlService.initRules()
 			let info = {
@@ -184,39 +199,45 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('check behaviour of _parseRules', function() {
 			it('with missing pos', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let	pfqlService = new PFQLService([setsOfRules])
 				pfqlService.initRules()
 				expect(pfqlService.parsedSetsOfRules[0][0].pos).to.be.null
 				expect(pfqlService.parsedSetsOfRules[0][0].Npos).to.not.be.null
 			})
 			it('with missing Npos', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let	pfqlService = new PFQLService([setsOfRules])
 				pfqlService.initRules()
 				expect(pfqlService.parsedSetsOfRules[0][0].pos).to.not.be.null
 				expect(pfqlService.parsedSetsOfRules[0][0].Npos).to.be.null
 			})
 			it('with missing Npos and pos', function() {
-				let setsOfRules = [{}]
+				let setsOfRules = {
+					rules: [{}]
+				}
 				let	pfqlService = new PFQLService([setsOfRules])
 				pfqlService.initRules()
 				expect(pfqlService.parsedSetsOfRules[0][0].pos).to.be.null
@@ -262,7 +283,7 @@ describe('Feature Query Language - FQL', function() {
 						]
 					]
 				}
-				let	pfqlService = new PFQLService([[rules]])
+				let	pfqlService = new PFQLService([{rules: [rules]}])
 				pfqlService.initRules()
 				let parsed = pfqlService._parseRules(rules, 0)
 				expect(parsed).eql(expected)
@@ -316,7 +337,7 @@ describe('Feature Query Language - FQL', function() {
 						]
 					]
 				}
-				let	pfqlService = new PFQLService([[rules]])
+				let	pfqlService = new PFQLService([{rules: [rules]}])
 				pfqlService.initRules()
 				let parsed = pfqlService._parseRules(rules, 0)
 				expect(parsed).eql(expected)
@@ -351,7 +372,7 @@ describe('Feature Query Language - FQL', function() {
 					},
 					Npos: null
 				}
-				let	pfqlService = new PFQLService([[rules]])
+				let	pfqlService = new PFQLService([{rules: [rules]}])
 				pfqlService.initRules()
 				let parsed = pfqlService._parseRules(rules, 0)
 				expect(parsed).eql(expected)
@@ -360,45 +381,45 @@ describe('Feature Query Language - FQL', function() {
 		describe('Checking behaviour of _parseCount', function() {
 			it('Too many commas', function() {
 				let countInfo = '{1,2,3}'
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				expect(pfqlService._parseCount.bind(pfqlService, countInfo)).to.throw('Invalid count value (too many commas): ' + countInfo)
 			})
 			it('It must be an integer 1', function() {
 				let countInfo = '{1,a}'
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				expect(pfqlService._parseCount.bind(pfqlService, countInfo)).to.throw('Invalid count value (only integers): ' + countInfo)
 			})
 			it('It must be an integer 2', function() {
 				let countInfo = '{1,2.3}'
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				expect(pfqlService._parseCount.bind(pfqlService, countInfo)).to.throw('Invalid count value (only integers): ' + countInfo)
 			})
 			it('It must work with single number', function() {
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				let countInfo = '{7}',
 					parsed = pfqlService._parseCount(countInfo)
 				expect(parsed).eql([7, 7])
 			})
 			it('It must work with two numbers', function() {
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				let countInfo = '{1,7}',
 					parsed = pfqlService._parseCount(countInfo)
 				expect(parsed).eql([1, 7])
 			})
 			it('It must work with no number in the first place', function() {
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				let countInfo = '{,7}',
 					parsed = pfqlService._parseCount(countInfo)
 				expect(parsed).eql([0, 7])
 			})
 			it('It must work with no number in the second place', function() {
-				let pfqlService = new PFQLService([[]])
+				let pfqlService = new PFQLService([{rules: []}])
 				pfqlService.initRules()
 				let countInfo = '{1,}',
 					parsed = pfqlService._parseCount(countInfo)
@@ -418,24 +439,26 @@ describe('Feature Query Language - FQL', function() {
 			expect(pfqlService.query).eql([simpleRule])
 		})
 		it('After initRules, all resources used in rules should appear in .resources', function() {
-			let setsOfRules = [
-				{
-					pos: [
-						{
-							resource: 'pfam29',
-							feature: 'CheW'
-						},
-						{
-							resource: 'pfam29',
-							feature: 'Response_reg'
-						},
-						{
-							resource: 'das',
-							feature: 'TM'
-						}
-					]
-				}
-			]
+			let setsOfRules = {
+				rules: [
+					{
+						pos: [
+							{
+								resource: 'pfam29',
+								feature: 'CheW'
+							},
+							{
+								resource: 'pfam29',
+								feature: 'Response_reg'
+							},
+							{
+								resource: 'das',
+								feature: 'TM'
+							}
+						]
+					}
+				]
+			}
 			let	pfqlService = new PFQLService([setsOfRules])
 			pfqlService.initRules(setsOfRules)
 			let expected = ['pfam29', 'das']
@@ -443,16 +466,18 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Missing pos or Npos in arguments should pass pos and Npos null rules', function() {
 			it('Missing pos should pass undefined for rules.pos', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let	pfqlService = new PFQLService([setsOfRules])
 				pfqlService.initRules()
 				expect(pfqlService.query[0].pos).to.be.undefined
@@ -460,164 +485,180 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Checking the integrity of rules - should throw informative Errors', function() {
 			it('Missing mandatory field in pos type rule resource should throw Error', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'pfam29',
-								feature: 'CheW'
-							},
-							{
-								feature: 'Response_reg'
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam29',
+									feature: 'CheW'
+								},
+								{
+									feature: 'Response_reg'
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Each pos rule must explicitly define a resource: \n{"feature":"Response_reg"}')
 			})
 			it('Missing mandatory field in pos type rule feature should throw Error', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'pfam29',
-								feature: 'CheW'
-							},
-							{
-								resource: 'pfam29'
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam29',
+									feature: 'CheW'
+								},
+								{
+									resource: 'pfam29'
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Each pos rule must explicitly define a feature: \n{"resource":"pfam29"}')
 			})
 			it('Missing both mandatory fields in pos type rule resource and feature should throw Error', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'pfam29',
-								feature: 'CheW'
-							},
-							{
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam29',
+									feature: 'CheW'
+								},
+								{
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Each pos rule must explicitly define a resource and feature: \n{}')
 			})
 			it('Missing mandatory field in Npos type rule resource should throw Error', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam29',
-								feature: 'CheW'
-							},
-							{
-								feature: 'Response_reg'
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam29',
+									feature: 'CheW'
+								},
+								{
+									feature: 'Response_reg'
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Each Npos rule must explicitly define a resource: \n{"feature":"Response_reg"}')
 			})
 			it('Missing mandatory field in Npos type rule feature should throw Error', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam29',
-								feature: 'CheW'
-							},
-							{
-								resource: 'pfam29'
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam29',
+									feature: 'CheW'
+								},
+								{
+									resource: 'pfam29'
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Each Npos rule must explicitly define a feature: \n{"resource":"pfam29"}')
 			})
 			it('Missing both mandatory fields in Npos type rule resource and feature should throw Error', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam29',
-								feature: 'CheW'
-							},
-							{
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam29',
+									feature: 'CheW'
+								},
+								{
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Each Npos rule must explicitly define a resource and feature: \n{}')
 			})
 			it('Wrong wild card "*" instead of ".*" in positional rules', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: '*',
-								count: '{2}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: '*',
+									count: '{2}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Wrong wild card. Change "*" to ".*" in:\n{"resource":"pfam28","feature":"*","count":"{2}"}')
 			})
 			it('Wrong wild card "*" instead of ".*" in non-positional rules', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: '*',
-								count: '{2}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: '*',
+									count: '{2}'
+								}
+							]
+						}
+					]
+				}
 				let pfqlService = new PFQLService([setsOfRules])
 				expect(pfqlService.initRules.bind(pfqlService)).to.throw('Wrong wild card. Change "*" to ".*" in:\n{"resource":"pfam28","feature":"*","count":"{2}"}')
 			})
@@ -626,16 +667,18 @@ describe('Feature Query Language - FQL', function() {
 	describe('Non positional rules :: ', function() {
 		describe('Single Rule - If broken, fix this first', function() {
 			it('Filter proteins sequences with any number of matches, anywhere in the sequence, to a single CheW domain from pfam29', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -672,17 +715,19 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences with 1 or 2 matches, anywhere in the sequence, to a single CheW domain from pfam29', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{1,2}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{1,2}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -719,17 +764,19 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences with 2 or 3 matches, anywhere in the sequence, to a single CheW domain from pfam29', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2,3}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2,3}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -766,17 +813,19 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences with 3 or more transmembrane regions, anywhere in the sequence', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{3,}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{3,}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -813,17 +862,19 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences without transmembrane regions', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{0}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{0}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -860,17 +911,19 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins with 1 domain from pfam28', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -909,22 +962,24 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Multiple Rules - AND mode', function() {
 			it('Filter proteins sequences with at least 1 match to CheW domain in pfam28 AND only 1 match to HATPase_c domain in pfam28', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'HATPase_c',
-								count: '{1}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'HATPase_c',
+									count: '{1}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -961,27 +1016,29 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences with at least 1 match to CheW domain in pfam28 AND only 1 match to HATPase_c domain in pfam28', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'HATPase_c',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Response_reg',
-								count: '{0}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'HATPase_c',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Response_reg',
+									count: '{0}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1020,26 +1077,28 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Multiple Rules - OR mode', function() {
 			it('Filter proteins sequences with at least 2 matches to CheW domain in pfam28 OR only 1 match to HATPase_c domain in pfam28', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2,}'
-							}
-						]
-					},
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'HATPase_c',
-								count: '{1}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2,}'
+								}
+							]
+						},
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'HATPase_c',
+									count: '{1}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1076,35 +1135,37 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences with at least 2 match to CheW domain in pfam28 OR only 1 match to HATPase_c domain in pfam28 OR only 1 matches to Response_reg in pfam28', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2,}'
-							}
-						]
-					},
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'HATPase_c',
-								count: '{1}'
-							}
-						]
-					},
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'Response_reg',
-								count: '{1}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2,}'
+								}
+							]
+						},
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'HATPase_c',
+									count: '{1}'
+								}
+							]
+						},
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'Response_reg',
+									count: '{1}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -1145,20 +1206,22 @@ describe('Feature Query Language - FQL', function() {
 	describe('Positional rules :: ', function() {
 		describe('Simple matches :: ', function() {
 			it('Filter protein sequences starting with 1 match to a CheW domain from Pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -1195,21 +1258,23 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with 2 CheW domains from Pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1246,21 +1311,23 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with 2 or more CheW domains from Pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2,}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2,}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1297,26 +1364,28 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with 1 TM followed by 1 Cache_2 domain from Pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_2',
-								count: '{1}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Cache_2',
+									count: '{1}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1353,38 +1422,40 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with 1 TM follow by any 2 feature and another TM', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{2}'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1,}'
-							}
-						],
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{0,}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{2}'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1,}'
+								}
+							],
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{0,}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1421,16 +1492,18 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter proteins sequences with any number of matches, anywhere in the sequence, to a single domain from pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -1468,26 +1541,30 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Non-positional and positional rules can have the same output', function() {
-				let setsOfRulesPos = [
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
-				let setsOfRulesNonPos = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				let setsOfRulesPos = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
+				let setsOfRulesNonPos = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 				let query = [setsOfRulesPos, setsOfRulesNonPos]
 				let expected = [
 					[0, 1], // CheW | CheW
@@ -1526,26 +1603,30 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Don\'t know why doesn\'t work - Two different rules should not give the same output', function() {
-				let setsOfRulesPos = [
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
-				let setsOfRulesNonPos = [
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'MCPSignal'
-							}
-						]
-					}
-				]
+				let setsOfRulesPos = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
+				let setsOfRulesNonPos = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'MCPSignal'
+								}
+							]
+						}
+					]
+				}
 				let pfqlServiceP = new PFQLService([setsOfRulesPos]),
 					pfqlServiceNP = new PFQLService([setsOfRulesNonPos])
 
@@ -1565,24 +1646,26 @@ describe('Feature Query Language - FQL', function() {
 				expect(resultsP).not.eql(resultsNP)
 			})
 			it('Filter protein sequences with 1 match to a CheW domain from Pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1620,40 +1703,42 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter sequences with starts with TM-Cache_1 and end in MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_1',
-								count: '{1}'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Cache_1',
+									count: '{1}'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1691,47 +1776,49 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter sequences with starts with TM-Cache_1 followed by anything BUT another Cache_1 and end in MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_1',
-								count: '{1}'
-							},
-							[
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
 								{
-									resource: '.*',
-									feature: '.*',
-									count: '{1,}'
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
 								},
 								{
 									resource: 'pfam28',
 									feature: 'Cache_1',
-									count: '{0}'
+									count: '{1}'
+								},
+								[
+									{
+										resource: '.*',
+										feature: '.*',
+										count: '{1,}'
+									},
+									{
+										resource: 'pfam28',
+										feature: 'Cache_1',
+										count: '{0}'
+									}
+								],
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
 								}
-							],
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1769,40 +1856,42 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter sequences with starts with TM-Cache_2 and end in MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_2',
-								count: '{1}'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Cache_2',
+									count: '{1}'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1842,25 +1931,27 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Testing the behaviour of "count" for positional rules :: ', function() {
 			it('Request protein sequences with 2 matches and nothing else to a single domain from pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1898,25 +1989,27 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Request protein sequences with 3 matches and nothing else to a single domain from pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{3}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{3}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -1954,25 +2047,27 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences with 2 or 3 matches and nothing else to a single domain from pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2,3}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2,3}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2010,21 +2105,23 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Request protein sequences with 2 or 3 matches at the end of the sequence to a single domain from pfam28', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW',
-								count: '{2,3}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW',
+									count: '{2,3}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2062,27 +2159,29 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Request protein sequences with 2 TM regions anywhere in the sequence with MCPsignal at the end', function() {
-				let setsOfRules = [
-					{
-						Npos: [
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{2}'
-							}
-						],
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{2}'
+								}
+							],
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2122,25 +2221,27 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Testing the behaviour of wildcard for positional rules', function() {
 			it('Filter protein sequences with any 2 pfam28 domains', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{2}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{2}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[0], // CheW | CheW
 					[0], // CheW | Response_reg
@@ -2178,45 +2279,47 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences with 1 or more domains between 2 TM regions in the beginning of the sequence and with MCPsignal at the end', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2254,52 +2357,54 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with no Cache_1 between two TM and ending a MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							[
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
 								{
-									resource: 'pfam28',
-									feature: 'Cache_1',
-									count: '{0}'
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								[
+									{
+										resource: 'pfam28',
+										feature: 'Cache_1',
+										count: '{0}'
+									},
+									{
+										resource: 'pfam28',
+										feature: '.*',
+										count: '{1,}'
+									}
+								],
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
 								},
 								{
 									resource: 'pfam28',
 									feature: '.*',
 									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
 								}
-							],
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2337,64 +2442,66 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with TM followed by any two domains from pfam28 but no Cache_1 followed by another TM and ending a MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							[
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
 								{
-									resource: 'pfam28',
-									feature: '.*',
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								[
+									{
+										resource: 'pfam28',
+										feature: '.*',
+										count: '{1}'
+									},
+									{
+										resource: 'pfam28',
+										feature: 'Cache_1',
+										count: '{0}'
+									}
+								],
+								[
+									{
+										resource: 'pfam28',
+										feature: '.*',
+										count: '{1}'
+									},
+									{
+										resource: 'pfam28',
+										feature: 'Cache_1',
+										count: '{0}'
+									}
+								],
+								{
+									resource: 'das',
+									feature: 'TM',
 									count: '{1}'
 								},
 								{
 									resource: 'pfam28',
-									feature: 'Cache_1',
-									count: '{0}'
-								}
-							],
-							[
-								{
-									resource: 'pfam28',
 									feature: '.*',
-									count: '{1}'
+									count: '{1,}'
 								},
 								{
 									resource: 'pfam28',
-									feature: 'Cache_1',
-									count: '{0}'
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
 								}
-							],
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2432,57 +2539,59 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences starting with TM followed by any two domains from pfam28 but Cache_1 not in the first of the two followed by another TM and ending a MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							[
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
 								{
-									resource: 'pfam28',
-									feature: 'Cache_1',
-									count: '{0}'
+									resource: 'fql',
+									feature: '^'
 								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								[
+									{
+										resource: 'pfam28',
+										feature: 'Cache_1',
+										count: '{0}'
+									},
+									{
+										resource: 'pfam28',
+										feature: '.*',
+										count: '{1}'
+									}
+								],
 								{
 									resource: 'pfam28',
 									feature: '.*',
 									count: '{1}'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
 								}
-							],
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1}'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2520,34 +2629,36 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter sequences that start with TM and end with MCPsignal.', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2585,21 +2696,23 @@ describe('Feature Query Language - FQL', function() {
 				expect(results).eql(expected)
 			})
 			it('Filter protein sequences that starts with at least 3 domains of the PAS family using wildcards "PAS.*"', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'PAS.*',
-								count: '{3}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'PAS.*',
+									count: '{3}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2641,72 +2754,74 @@ describe('Feature Query Language - FQL', function() {
 	describe('Complex queries', function() {
 		describe('Same position specified in two rules should mean OR', function() {
 			it('Filter sequences with starts with TM-Cache_1 or TM-Cache_2 and end in MCPsignal', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_2',
-								count: '{1}'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					},
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_1',
-								count: '{1}'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Cache_2',
+									count: '{1}'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						},
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Cache_1',
+									count: '{1}'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2746,47 +2861,49 @@ describe('Feature Query Language - FQL', function() {
 		})
 		describe('Combining Npos and pos rules', function() {
 			it('Filter protein sequences that starts with TM-Cache1 and ends with MCPsignal but does not have Cache_2 anywhere', function() {
-				let setsOfRules = [
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'Cache_1',
-								count: '{1}'
-							},
-							{
-								resource: '.*',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						],
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'Cache_2',
-								count: '{0}'
-							}
-						]
-					}
-				]
+				let setsOfRules = {
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'Cache_1',
+									count: '{1}'
+								},
+								{
+									resource: '.*',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							],
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'Cache_2',
+									count: '{0}'
+								}
+							]
+						}
+					]
+				}
 				let expected = [
 					[], // CheW | CheW
 					[], // CheW | Response_reg
@@ -2828,26 +2945,30 @@ describe('Feature Query Language - FQL', function() {
 	describe('Sets of rules should also work', function() {
 		it('two equal rules must match same entries', function() {
 			let query = [
-				[
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				],
-				[
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				},
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 			]
 			let expected = [
 				[0, 1], // CheW | CheW
@@ -2885,55 +3006,59 @@ describe('Feature Query Language - FQL', function() {
 		})
 		it('Two different rules matching different entries', function() {
 			let query = [
-				[
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				],
-				[
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				},
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 			]
 			let expected = [
 				[0], // CheW | CheW
@@ -2972,74 +3097,80 @@ describe('Feature Query Language - FQL', function() {
 		})
 		it('Overlapping rules matching different entries', function() {
 			let query = [
-				[
-					{
-						pos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				],
-				[
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'das',
-								feature: 'TM',
-								count: '{1}'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{1,}'
-							},
-							{
-								resource: 'pfam28',
-								feature: 'MCPsignal',
-								count: '{1}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				],
-				[
-					{
-						pos: [
-							{
-								resource: 'fql',
-								feature: '^'
-							},
-							{
-								resource: 'pfam28',
-								feature: '.*',
-								count: '{2}'
-							},
-							{
-								resource: 'fql',
-								feature: '$'
-							}
-						]
-					}
-				]
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				},
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'das',
+									feature: 'TM',
+									count: '{1}'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{1,}'
+								},
+								{
+									resource: 'pfam28',
+									feature: 'MCPsignal',
+									count: '{1}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				},
+				{
+					rules: [
+						{
+							pos: [
+								{
+									resource: 'fql',
+									feature: '^'
+								},
+								{
+									resource: 'pfam28',
+									feature: '.*',
+									count: '{2}'
+								},
+								{
+									resource: 'fql',
+									feature: '$'
+								}
+							]
+						}
+					]
+				}
 			]
 			let expected = [
 				[0, 2], // CheW | CheW
@@ -3080,24 +3211,26 @@ describe('Feature Query Language - FQL', function() {
 	describe('Using multiple resources', function() {
 		it(':: testing pfam28 and smart in the same set', function() {
 			let query = [
-				[
-					{
-						Npos: [
-							{
-								resource: 'smart',
-								feature: 'SM00260'
-							}
-						]
-					},
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				{
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'smart',
+									feature: 'SM00260'
+								}
+							]
+						},
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 			]
 			let expected = [
 				[0], // CheW | CheW
@@ -3136,26 +3269,30 @@ describe('Feature Query Language - FQL', function() {
 		})
 		it(':: testing pfam28 and smart in different sets', function() {
 			let query = [
-				[
-					{
-						Npos: [
-							{
-								resource: 'smart',
-								feature: 'SM00260'
-							}
-						]
-					}
-				],
-				[
-					{
-						Npos: [
-							{
-								resource: 'pfam28',
-								feature: 'CheW'
-							}
-						]
-					}
-				]
+				{
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'smart',
+									feature: 'SM00260'
+								}
+							]
+						}
+					]
+				},
+				{
+					rules: [
+						{
+							Npos: [
+								{
+									resource: 'pfam28',
+									feature: 'CheW'
+								}
+							]
+						}
+					]
+				}
 			]
 			let expected = [
 				[0, 1], // CheW | CheW

--- a/src/PFQLStream.tests.js
+++ b/src/PFQLStream.tests.js
@@ -15,22 +15,24 @@ describe('PFQLStream test suit ::', function() {
 		})
 		readable.push(null)
 
-		let setOfRules = [
-			[
-				{
-					pos: [
-						{
-							resource: 'pfam28',
-							feature: 'CheW',
-							count: '{2,3}'
-						},
-						{
-							resource: 'fql',
-							feature: '$'
-						}
-					]
-				}
-			]
+		let query = [
+			{
+				rules: [
+					{
+						pos: [
+							{
+								resource: 'pfam28',
+								feature: 'CheW',
+								count: '{2,3}'
+							},
+							{
+								resource: 'fql',
+								feature: '$'
+							}
+						]
+					}
+				]
+			}
 		]
 
 		let expected = [
@@ -62,7 +64,7 @@ describe('PFQLStream test suit ::', function() {
 
 		let listOfData = []
 
-		let pfqlStream = new PFQLStream(setOfRules)
+		let pfqlStream = new PFQLStream(query)
 		pfqlStream.progressReportNumber = 1
 		readable.pipe(pfqlStream)
 			.on('data', function(item) {


### PR DESCRIPTION
## Changes the way it reads query

before:  
```javascript
let query = [
	{
		pos: [
			{
				resource: 'pfam28',
				feature: 'CheW',
				count: '{2,3}'
			},
			{
				resource: 'fql',
				feature: '$'
			}
		]
	}
]

from now on:
```javascript
let query = [
	{
		rules: [
			{
				pos: [
					{
						resource: 'pfam28',
						feature: 'CheW',
						count: '{2,3}'
					},
					{
						resource: 'fql',
						feature: '$'
					}
				]
			}
		]
	}
]
```